### PR TITLE
Verify Form Values are Present Before Getting

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -509,18 +509,18 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{paramName}}Param := strings.Split(r.FormValue("{{baseName}}"), ",")
 	{{/isArray}}
 	{{^isArray}}
-	{{paramName}}FormVal, ok := r.Form["{{baseName}}"]
+	{{paramName}}FormValues, ok := r.Form["{{baseName}}"]
 	{{#required}}
-	if !ok {
+	if !ok || len({{paramName}}FormValues) < 1 {
 		c.errorHandler(w, r, &RequiredError{"{{baseName}}"}, nil)
 		return
 	}
-	{{paramName}}Param := getPointer({{paramName}}FormVal)
+	{{paramName}}Param := getPointer({{paramName}}FormValues[0])
 	{{/required}}
 	{{^required}}
 	var {{paramName}}Param *string
-	if ok {
-		{{paramName}}Param = getPointer({{paramName}})
+	if ok && len({{paramName}}FormValues) > 0 {
+		{{paramName}}Param = getPointer({{paramName}}FormValues[0])
 	}
 	{{/required}}
 	{{/isArray}}

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -509,11 +509,18 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{paramName}}Param := strings.Split(r.FormValue("{{baseName}}"), ",")
 	{{/isArray}}
 	{{^isArray}}
-	{{paramName}}Param := getPointerOrNilIfEmpty(r.FormValue("{{baseName}}"))
+	{{paramName}}FormVal, ok := r.Form["{{baseName}}"]
 	{{#required}}
-	if {{paramName}}Param == nil {
+	if !ok {
 		c.errorHandler(w, r, &RequiredError{"{{baseName}}"}, nil)
 		return
+	}
+	{{paramName}}Param := getPointer({{paramName}}FormVal)
+	{{/required}}
+	{{^required}}
+	var {{paramName}}Param *string
+	if ok {
+		{{paramName}}Param = getPointer({{paramName}})
 	}
 	{{/required}}
 	{{/isArray}}

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_pet.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_pet.go
@@ -247,10 +247,18 @@ func (c *PetAPIController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	}
 	
 	
-	nameParam := getPointerOrNilIfEmpty(r.FormValue("name"))
+	nameFormValues, ok := r.Form["name"]
+	var nameParam *string
+	if ok && len(nameFormValues) > 0 {
+		nameParam = getPointer(nameFormValues[0])
+	}
 	
 	
-	statusParam := getPointerOrNilIfEmpty(r.FormValue("status"))
+	statusFormValues, ok := r.Form["status"]
+	var statusParam *string
+	if ok && len(statusFormValues) > 0 {
+		statusParam = getPointer(statusFormValues[0])
+	}
 	result, err := c.service.UpdatePetWithForm(r.Context(), *petIdParam, nameParam, statusParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
@@ -277,7 +285,11 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	}
 	
 	
-	additionalMetadataParam := getPointerOrNilIfEmpty(r.FormValue("additionalMetadata"))
+	additionalMetadataFormValues, ok := r.Form["additionalMetadata"]
+	var additionalMetadataParam *string
+	if ok && len(additionalMetadataFormValues) > 0 {
+		additionalMetadataParam = getPointer(additionalMetadataFormValues[0])
+	}
 	fileParam, err := ReadFormFileToTempFile(r, "file")
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -424,10 +424,18 @@ func (c *PetAPIController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	}
 	
 	
-	nameParam := getPointerOrNilIfEmpty(r.FormValue("name"))
+	nameFormValues, ok := r.Form["name"]
+	var nameParam *string
+	if ok && len(nameFormValues) > 0 {
+		nameParam = getPointer(nameFormValues[0])
+	}
 	
 	
-	statusParam := getPointerOrNilIfEmpty(r.FormValue("status"))
+	statusFormValues, ok := r.Form["status"]
+	var statusParam *string
+	if ok && len(statusFormValues) > 0 {
+		statusParam = getPointer(statusFormValues[0])
+	}
 	result, err := c.service.UpdatePetWithForm(r.Context(), *petIdParam, nameParam, statusParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
@@ -455,7 +463,11 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	}
 	
 	
-	additionalMetadataParam := getPointerOrNilIfEmpty(r.FormValue("additionalMetadata"))
+	additionalMetadataFormValues, ok := r.Form["additionalMetadata"]
+	var additionalMetadataParam *string
+	if ok && len(additionalMetadataFormValues) > 0 {
+		additionalMetadataParam = getPointer(additionalMetadataFormValues[0])
+	}
 	
 	
 	extraOptionalMetadataParam := strings.Split(r.FormValue("extraOptionalMetadata"), ",")
@@ -493,7 +505,11 @@ func (c *PetAPIController) UploadFileArrayOfFiles(w http.ResponseWriter, r *http
 	}
 	
 	
-	additionalMetadataParam := getPointerOrNilIfEmpty(r.FormValue("additionalMetadata"))
+	additionalMetadataFormValues, ok := r.Form["additionalMetadata"]
+	var additionalMetadataParam *string
+	if ok && len(additionalMetadataFormValues) > 0 {
+		additionalMetadataParam = getPointer(additionalMetadataFormValues[0])
+	}
 	filesParam, err := ReadFormFilesToTempFiles(r, "files")
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)

--- a/samples/server/petstore/go-chi-server/go/api_pet.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet.go
@@ -417,10 +417,18 @@ func (c *PetAPIController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	}
 	
 	
-	nameParam := getPointerOrNilIfEmpty(r.FormValue("name"))
+	nameFormValues, ok := r.Form["name"]
+	var nameParam *string
+	if ok && len(nameFormValues) > 0 {
+		nameParam = getPointer(nameFormValues[0])
+	}
 	
 	
-	statusParam := getPointerOrNilIfEmpty(r.FormValue("status"))
+	statusFormValues, ok := r.Form["status"]
+	var statusParam *string
+	if ok && len(statusFormValues) > 0 {
+		statusParam = getPointer(statusFormValues[0])
+	}
 	result, err := c.service.UpdatePetWithForm(r.Context(), *petIdParam, nameParam, statusParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
@@ -447,7 +455,11 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	}
 	
 	
-	additionalMetadataParam := getPointerOrNilIfEmpty(r.FormValue("additionalMetadata"))
+	additionalMetadataFormValues, ok := r.Form["additionalMetadata"]
+	var additionalMetadataParam *string
+	if ok && len(additionalMetadataFormValues) > 0 {
+		additionalMetadataParam = getPointer(additionalMetadataFormValues[0])
+	}
 	
 	
 	extraOptionalMetadataParam := strings.Split(r.FormValue("extraOptionalMetadata"), ",")
@@ -484,7 +496,11 @@ func (c *PetAPIController) UploadFileArrayOfFiles(w http.ResponseWriter, r *http
 	}
 	
 	
-	additionalMetadataParam := getPointerOrNilIfEmpty(r.FormValue("additionalMetadata"))
+	additionalMetadataFormValues, ok := r.Form["additionalMetadata"]
+	var additionalMetadataParam *string
+	if ok && len(additionalMetadataFormValues) > 0 {
+		additionalMetadataParam = getPointer(additionalMetadataFormValues[0])
+	}
 	filesParam, err := ReadFormFilesToTempFiles(r, "files")
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)


### PR DESCRIPTION
If a form value wasn't populated in the request body, the previous code would return an `""`. Instead we will check if it is provided and returning a `nil` if it's not provided.