### PR TITLE
TS-38585 - Remove empty value check in parseBoolParameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -343,9 +343,6 @@ func parseNumericParameter[T Number](param string, fn Operation[T], checks ...Co
 
 // parseBoolParameter parses a string parameter to a bool
 func parseBoolParameter(param string, fn Operation[bool]) (*bool, error) {
-	if param == "" {
-		return nil, nil
-	}
 	v, _, err := fn(param)
 	return v, err
 }

--- a/samples/openapi3/server/petstore/go/go-petstore/go/routers.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/routers.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -74,7 +75,7 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 			return err
 		}
 		wHeader.Set("Content-Type", http.DetectContentType(data))
-		wHeader.Set("Content-Disposition", "attachment; filename="+f.Name())
+		wHeader.Set("Content-Disposition", "attachment; filename="+filepath.Base(f.Name()))
 		if status != nil {
 			w.WriteHeader(*status)
 		} else {
@@ -310,9 +311,6 @@ func parseNumericParameter[T Number](param string, fn Operation[T], checks ...Co
 
 // parseBoolParameter parses a string parameter to a bool
 func parseBoolParameter(param string, fn Operation[bool]) (*bool, error) {
-	if param == "" {
-		return nil, nil
-	}
 	v, _, err := fn(param)
 	return v, err
 }

--- a/samples/server/others/go-server/no-body-path-params/go/routers.go
+++ b/samples/server/others/go-server/no-body-path-params/go/routers.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -78,7 +79,7 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 			return err
 		}
 		wHeader.Set("Content-Type", http.DetectContentType(data))
-		wHeader.Set("Content-Disposition", "attachment; filename="+f.Name())
+		wHeader.Set("Content-Disposition", "attachment; filename="+filepath.Base(f.Name()))
 		if status != nil {
 			w.WriteHeader(*status)
 		} else {
@@ -314,9 +315,6 @@ func parseNumericParameter[T Number](param string, fn Operation[T], checks ...Co
 
 // parseBoolParameter parses a string parameter to a bool
 func parseBoolParameter(param string, fn Operation[bool]) (*bool, error) {
-	if param == "" {
-		return nil, nil
-	}
 	v, _, err := fn(param)
 	return v, err
 }

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -78,7 +79,7 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 			return err
 		}
 		wHeader.Set("Content-Type", http.DetectContentType(data))
-		wHeader.Set("Content-Disposition", "attachment; filename="+f.Name())
+		wHeader.Set("Content-Disposition", "attachment; filename="+filepath.Base(f.Name()))
 		if status != nil {
 			w.WriteHeader(*status)
 		} else {
@@ -314,9 +315,6 @@ func parseNumericParameter[T Number](param string, fn Operation[T], checks ...Co
 
 // parseBoolParameter parses a string parameter to a bool
 func parseBoolParameter(param string, fn Operation[bool]) (*bool, error) {
-	if param == "" {
-		return nil, nil
-	}
 	v, _, err := fn(param)
 	return v, err
 }

--- a/samples/server/petstore/go-chi-server/go/routers.go
+++ b/samples/server/petstore/go-chi-server/go/routers.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -74,7 +75,7 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 			return err
 		}
 		wHeader.Set("Content-Type", http.DetectContentType(data))
-		wHeader.Set("Content-Disposition", "attachment; filename="+f.Name())
+		wHeader.Set("Content-Disposition", "attachment; filename="+filepath.Base(f.Name()))
 		if status != nil {
 			w.WriteHeader(*status)
 		} else {
@@ -310,9 +311,6 @@ func parseNumericParameter[T Number](param string, fn Operation[T], checks ...Co
 
 // parseBoolParameter parses a string parameter to a bool
 func parseBoolParameter(param string, fn Operation[bool]) (*bool, error) {
-	if param == "" {
-		return nil, nil
-	}
 	v, _, err := fn(param)
 	return v, err
 }


### PR DESCRIPTION
This PR removes the erroneous empty value check in `parseBooleanParameter` which was added in #1.  This broke default boolean parameters because it would cause `nil` to be returned before the passed `WithDefaultOrParse` function could be called.

This is my first `openapi-generator` PR! 🥳  I'm not totally sure what all I need to do here to test the fix.  Are there unit tests that I need to update and/or run locally?

Below I'll list my development steps; let me know if I'm missing anything!

- Made and committed the fix
- Ran `./mvnw clean package`
- Copied `modules/openapi-generator-cli/target/openapi-generator-cli.jar` over to the `lumos` repository
- Ran `./bin/generate-samples.sh ./bin/configs/*.yaml` and `./bin/utils/export_docs_generators.sh`
- Committed the updated generated files